### PR TITLE
Upgrade Django to make our GitHub Actions pass

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 asgiref==3.3.1
-Django==3.1.6
+Django==3.1.7
 django-crispy-forms==1.11.0
 pytz==2021.1
 sqlparse==0.4.1


### PR DESCRIPTION
Fix security issue `CVE-2021-23336: Web cache poisoning via django.utils.http.limited_parse_qsl()` discovered by [Safety](https://github.com/pyupio/safety) in our GitHub Actions tests https://docs.djangoproject.com/en/3.1/releases/3.1.7/